### PR TITLE
add text scaler information to expand text widget

### DIFF
--- a/lib/src/expand_text.dart
+++ b/lib/src/expand_text.dart
@@ -184,6 +184,7 @@ class _ExpandTextState extends State<ExpandText>
     return LayoutBuilder(
       builder: (context, size) {
         final defaultTextStyle = (child as DefaultTextStyle).style;
+        final textScaler = MediaQuery.textScalerOf(context);
 
         final textPainter = TextPainter(
           text: TextSpan(
@@ -191,6 +192,7 @@ class _ExpandTextState extends State<ExpandText>
             style: defaultTextStyle,
           ),
           textDirection: TextDirection.ltr,
+          textScaler: textScaler,
           maxLines: widget.maxLines,
         )..layout(maxWidth: size.maxWidth);
 


### PR DESCRIPTION
This fixes an issue where text is not recognized as overflowing if user applied accessibility scaling of text. 
By default set to no scaling. 

PS: James McIntosh says 'hi!' :) 