### PR TITLE
set overflow and maxlines limit to null if text is expanded, otherwis…

### DIFF
--- a/lib/src/expand_text.dart
+++ b/lib/src/expand_text.dart
@@ -250,18 +250,6 @@ class _ExpandTextState extends State<ExpandText>
     );
   }
 
-  /// Returns the actual maximun number of allowed lines,
-  /// depending on [_isExpanded].
-  /// If `overflow` is set to ellipsis, it must not return null,
-  /// otherwise the entire app could explode :)
-  int? get _maxLines {
-    if (_isExpanded) {
-      return (widget.overflow == TextOverflow.ellipsis) ? 2 ^ 64 : null;
-    }
-
-    return widget.maxLines;
-  }
-
   @override
   Widget build(BuildContext context) {
     return AnimatedBuilder(
@@ -276,9 +264,9 @@ class _ExpandTextState extends State<ExpandText>
         child: Text(
           widget.data,
           textAlign: widget.textAlign,
-          overflow: widget.overflow,
+          overflow: _isExpanded ? null : widget.overflow,
           style: widget.style,
-          maxLines: _maxLines,
+          maxLines: _isExpanded ? null : widget.maxLines,
         ),
       ),
     );


### PR DESCRIPTION
This PR fixes getting maxLines value depending on whether text is expanded or not. 

The current _maxLines method returns the value of 66 if the text widget is expanded and has an ellipsis overflow. This has 2 issues. 
1) The overflow is irrelevant when the text is expanded
2) 2 ^ 64 returns 66 

The fix sets maxLines to be null if the text is expanded, otherwise use maxLines which is passed in.